### PR TITLE
Enable greenkeeper-lockfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,11 @@ before_install:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-  - npm install -g codeclimate-test-reporter
+  - yarn global add greenkeeper-lockfile@1
+  - yarn global add codeclimate-test-reporter
+before_script: greenkeeper-lockfile-update
 script: node_modules/karma/bin/karma start karma.conf.js --single-run
+after_script: greenkeeper-lockfile-upload
 after_success:
   - codeclimate-test-reporter < coverage/lcov.info
 addons:


### PR DESCRIPTION
Enable `greenkeeper-lockfile` to keep `yarn.lock` file updated.