### PR TITLE
Adhere to TypeScript Guidelines for General Types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 ### v0.0.13
 
+- Adhere to TypeScript Guidelines for General Types (see #43).
+
 - Improve code coverage to reach 100% (see #42).
 
 - Use `rimraf` instead of `rm -rf` (see #41).

--- a/src/org/osflash/signals/DeluxeSignal.ts
+++ b/src/org/osflash/signals/DeluxeSignal.ts
@@ -19,7 +19,7 @@ import { IEvent } from "./events/IEvent";
  * Project home: <a target="_top" href="http://github.com/robertpenner/as3-signals/">http://github.com/robertpenner/as3-signals/</a>
  */
 export class DeluxeSignal extends PrioritySignal {
-    protected _target: Object;
+    protected _target: any;
 
     /**
      * Creates a DeluxeSignal instance to dispatch events on behalf of a target object.
@@ -33,7 +33,7 @@ export class DeluxeSignal extends PrioritySignal {
      * NOTE: Subclasses cannot call super.apply(null, valueClasses),
      * but this constructor has logic to support super(valueClasses).
      */
-    constructor(target: Object = null, ...valueClasses: any[]) {
+    constructor(target: any = null, ...valueClasses: any[]) {
         // Cannot use super.apply(null, valueClasses), so allow the subclass to call super(valueClasses).
         valueClasses = valueClasses.length === 1 && valueClasses[0] instanceof Array ? valueClasses[0] : valueClasses;
 
@@ -45,11 +45,11 @@ export class DeluxeSignal extends PrioritySignal {
     }
 
     /** @inheritDoc */
-    public get target(): Object {
+    public get target(): any {
         return this._target;
     }
 
-    public set target(value: Object) {
+    public set target(value: any) {
         if (value === this._target) {
             return;
         }
@@ -109,7 +109,7 @@ export class DeluxeSignal extends PrioritySignal {
             return;
         }
 
-        let currentTarget: Object = this.target;
+        let currentTarget: any = this.target;
 
         while (currentTarget && currentTarget.hasOwnProperty("parent")) {
             currentTarget = (<any>currentTarget).parent;

--- a/src/org/osflash/signals/ISlot.ts
+++ b/src/org/osflash/signals/ISlot.ts
@@ -51,7 +51,7 @@ export interface ISlot {
      * Existing <code>params</code> are appended before the listener is called.
      * @param value The argument for the listener.
      */
-    execute1(value: Object): void;
+    execute1(value: any): void;
 
     /**
      * Executes a listener of arity <code>n</code> where <code>n</code> is

--- a/src/org/osflash/signals/Slot.ts
+++ b/src/org/osflash/signals/Slot.ts
@@ -57,7 +57,7 @@ export class Slot implements ISlot {
     /**
      * @inheritDoc
      */
-    public execute1(value: Object): void {
+    public execute1(value: any): void {
         if (!this._enabled) {
             return;
         }

--- a/src/org/osflash/signals/events/GenericEvent.ts
+++ b/src/org/osflash/signals/events/GenericEvent.ts
@@ -8,8 +8,8 @@ import { IPrioritySignal } from "../IPrioritySignal";
  */
 export class GenericEvent implements IEvent {
     protected _bubbles: boolean;
-    protected _target: Object;
-    protected _currentTarget: Object;
+    protected _target: any;
+    protected _currentTarget: any;
     protected _signal: IPrioritySignal;
 
     constructor(bubbles: boolean = false) {
@@ -26,20 +26,20 @@ export class GenericEvent implements IEvent {
     }
 
     /** @inheritDoc */
-    public get target(): Object {
+    public get target(): any {
         return this._target;
     }
 
-    public set target(value: Object) {
+    public set target(value: any) {
         this._target = value;
     }
 
     /** @inheritDoc */
-    public get currentTarget(): Object {
+    public get currentTarget(): any {
         return this._currentTarget;
     }
 
-    public set currentTarget(value: Object) {
+    public set currentTarget(value: any) {
         this._currentTarget = value;
     }
 

--- a/src/org/osflash/signals/events/IEvent.ts
+++ b/src/org/osflash/signals/events/IEvent.ts
@@ -5,12 +5,12 @@ export interface IEvent {
      * The object that originally dispatched the event.
      * When dispatched from an signal, the target is the object containing the signal.
      */
-    target: Object;
+    target: any;
 
     /**
      * The object that added the listener for the event.
      */
-    currentTarget: Object;
+    currentTarget: any;
 
     /**
      * The signal that dispatched the event.

--- a/test/org/osflash/signals/AmbiguousRelationshipTest.test.ts
+++ b/test/org/osflash/signals/AmbiguousRelationshipTest.test.ts
@@ -6,7 +6,7 @@ import { Signal } from "../../../../src/org/osflash/signals/Signal";
 import { failIfCalled } from "../../../util/TestBase";
 
 describe("AmbiguousRelationshipTest", () => {
-    let target: Object;
+    let target: any;
     let instance: Signal;
 
     beforeEach(() => {

--- a/test/org/osflash/signals/DeluxeSignalWithBubblingEventTest.test.ts
+++ b/test/org/osflash/signals/DeluxeSignalWithBubblingEventTest.test.ts
@@ -83,13 +83,13 @@ describe("DeluxeSignalWithBubblingEventTest", () => {
 });
 
 class Child implements IBubbleEventHandler {
-    public parent: Object;
+    public parent: any;
     public completed: DeluxeSignal;
     public name: string;
     public listener: Function = null;
     public popsBubbles: boolean = false;
 
-    constructor(parent: Object = null, name = "", listener = null) {
+    constructor(parent: any = null, name = "", listener = null) {
         this.parent = parent;
         this.name = name;
         this.listener = listener;

--- a/test/org/osflash/signals/MonoSignalDispatchNonEventTest.test.ts
+++ b/test/org/osflash/signals/MonoSignalDispatchNonEventTest.test.ts
@@ -38,7 +38,7 @@ describe("MonoSignalDispatchNonEventTest", () => {
         completed.dispatch(0, 0);
     });
 
-    function onZeroZero(a: Object, b: Object): void {
+    function onZeroZero(a: any, b: any): void {
         assert.equal(0, a);
         assert.equal(0, b);
     }

--- a/test/org/osflash/signals/PromiseTest.test.ts
+++ b/test/org/osflash/signals/PromiseTest.test.ts
@@ -25,13 +25,13 @@ describe("PromiseTest", () => {
     });
 
     it("addOncedListenerWillReceiveDataWhenPromiseIsDispatched()", () => {
-        let received: Object;
+        let received: any;
 
-        function listener(data: Object): void {
+        function listener(data: any): void {
             received = data;
         }
 
-        let object: Object = { hello: "world" };
+        let object: any = { hello: "world" };
         promise.addOnce(listener);
         promise.dispatch(object);
 
@@ -52,13 +52,13 @@ describe("PromiseTest", () => {
     });
 
     it("listenerWillReceiveDataWhenBoundAfterPromiseIsDispatched()", () => {
-        let received: Object;
+        let received: any;
 
-        function listener(data: Object): void {
+        function listener(data: any): void {
             received = data;
         }
 
-        let object: Object = { hello: "world" };
+        let object: any = { hello: "world" };
         promise.dispatch(object);
         promise.addOnce(listener);
 

--- a/test/org/osflash/signals/SignalDispatchNonEventTest.test.ts
+++ b/test/org/osflash/signals/SignalDispatchNonEventTest.test.ts
@@ -38,7 +38,7 @@ describe("SignalDispatchNonEventTest", () => {
         completed.dispatch(0, 0);
     });
 
-    function onZeroZero(a: Object, b: Object): void {
+    function onZeroZero(a: any, b: any): void {
         assert.equal(0, a);
         assert.equal(0, b);
     }


### PR DESCRIPTION
Remove usage of types Number, String, Boolean and Object
---

Adhere to strict type rules for general types, according to **TypeScript** guidelines:

> Don’t ever use the types **Number**, **String**, **Boolean**, or **Object**. These types refer to non-primitive boxed objects that are almost never used appropriately in JavaScript code.